### PR TITLE
Add PlacesResult::$rating property

### DIFF
--- a/src/Http/Result/PlacesResult.php
+++ b/src/Http/Result/PlacesResult.php
@@ -132,6 +132,11 @@ class PlacesResult extends GoogleMapsResult
 	 * @var string
 	 */
 	protected $adr_address = '';
+	
+	/**
+	 * @var float
+	 */
+	protected $rating = 0;
 
 	/**
 	 * @var array


### PR DESCRIPTION
Missing property $rating

Sentry log:
PHP Notice: Undefined property: Biscolab\GoogleMaps\Http\Result\PlacesResult::$rating in /var/www/dev.posmio.com/web/vendor/biscolab/google-maps-php-sdk/src/Abstracts/AbstractObject.php:189